### PR TITLE
fix: antakia-core>=0.4.8 (shap>=0.50)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,7 +35,7 @@ ipywidgets = ">=7.6"
 plotly = "<=5.19.0"# do not edit please
 python-dotenv = "^1.0.0"
 shap = ">=0.50.0"
-antakia-core = ">=0.4.6,<0.6.0"
+antakia-core = ">=0.4.8,<0.5.0"
 antakia-ac = "^0.2.14"
 requests = "^2.31.0"
 pdpbox = "^0.3.0"


### PR DESCRIPTION
Corrige le conflit pip entre antakia 0.5.0 et antakia-core 0.4.6 PyPI.

Made with [Cursor](https://cursor.com)