### PR TITLE
fix(ci): pin numba pour pip install antakia

### DIFF
--- a/.github/workflows/pytest.yaml
+++ b/.github/workflows/pytest.yaml
@@ -28,6 +28,7 @@ jobs:
             VER="0.5.1"
           fi
           echo "Testing antakia==${VER}"
+          pip install "numba>=0.59.0" "llvmlite>=0.42.0"
           pip install "antakia==${VER}" pytest pytest-cov mock
       - name: Run pytest
         run: python -m pytest --cov=antakia --cov-report term-missing tests


### PR DESCRIPTION
Évite le backtrack pip vers numba 0.56 (build wheel KO sur 3.11).

Made with [Cursor](https://cursor.com)